### PR TITLE
Fix Bug - Failing when too many redirects (m4)

### DIFF
--- a/Config/config.php
+++ b/Config/config.php
@@ -9,7 +9,7 @@
 return [
     'name'        => 'Friendly Captcha',
     'description' => 'Enables Friendly Captcha integration.',
-    'version'     => '1.0',
+    'version'     => '1.0.1',
     'author'      => 'Daniel Band',
 
     'routes' => [

--- a/Views/Integration/friendlycaptcha.html.php
+++ b/Views/Integration/friendlycaptcha.html.php
@@ -1,7 +1,8 @@
+<?php $jsElement = $jsElement ?? ''; ?>
 <?php
 
 $js = $view['assets']->getUrl('plugins/MauticFriendlyCaptchaBundle/Views/Public/js/add-captcha.js', null, null, true);
-$fcWidgetJs = $view['assets']->getUrl('plugins/MauticFriendlyCaptchaBundle/Views/Public/js/widget.js', null, null, true);
+$fcWidgetJs = $view['assets']->getUrl('plugins/MauticFriendlyCaptchaBundle/Views/Public/js/widget.min.js', null, null, true);
 $fcWidgetModuleJs = $view['assets']->getUrl('plugins/MauticFriendlyCaptchaBundle/Views/Public/js/widget.module.min.js', null, null, true);
 $siteKey   = $field['customParameters']['site_key'];
 

--- a/Views/Public/js/add-captcha.js
+++ b/Views/Public/js/add-captcha.js
@@ -1,7 +1,7 @@
 function addCaptcha(wrapper, inputName, siteKey) {
     const myCustomWidget = new friendlyChallenge.WidgetInstance(wrapper, {
         sitekey: siteKey,
-        startMode: 'auto',
+        startMode: 'focus',
         solutionFieldName: inputName
     });
 


### PR DESCRIPTION
When using the Captcha in a form on a Mautic Landing Page it seems to be working fine. But when using it on a website (e.g. on our test-wordpress https://batterywall.de/erneuerbare-energie/ ) it happens that the Captcha doesn’t appear and the submit of the form will fail. In the browser console we see “Error: Too many redirects https://ma.batterywall.de/plugins/MauticFriendlyCaptchaBundle/Views/Public/js/widget.js” 

This PR solves the problem. However the PR is meant to be made against v4.0 (https://github.com/TAWK-GmbH/mautic-friendlycaptcha/releases/tag/v4.0)

Is there any chance you could create an extra branch for Mautic 4 based in the v4.0 tag so that I could rebase to this branch?





